### PR TITLE
Fetch classifications with correct language

### DIFF
--- a/src/fs-detail.js
+++ b/src/fs-detail.js
@@ -257,10 +257,10 @@ const languages = {
     'fi': {'yesButton': 'Kyllä', 'noButton': 'Ei', 'feedbackQuestion': 'Oliko tämä hakemanne luokka?', 'feedbackReply': 'Kiitos palautteestanne!',
         'excludesText': 'Tähän ei kuulu: ', 'includesText': 'Tähän kuuluu: ', 'includesAlsoText': 'Tähän kuuluu myös: ', 'keywordsText': 'Synonyymit: '},
     'en': {'yesButton': 'Yes', 'noButton': 'No', 'feedbackQuestion': 'Is this the building class you are looking for?',
-        'feedbackReply': 'Thank you for your feedback!', 'excludesText': 'Excludes: ', 'includesText': 'Includes: ', 'includesAlsoText': 'Includes also:',
+        'feedbackReply': 'Thank you for your feedback!', 'excludesText': 'Excludes: ', 'includesText': 'Includes: ', 'includesAlsoText': 'Also includes:',
         'keywordsText': 'Keywords: '},
-    'sv': {'yesButton': 'Ja', 'noButton': 'Nej', 'feedbackQuestion': 'Är detta byggnadsklassen ni var efter?', 'feedbackReply':
-        'Tack för responsen!', 'excludesText': 'Innehåller inte: ', 'includesText': 'Innehåller: ', 'includesAlsoText': 'Innehåller också: ',
+    'sv': {'yesButton': 'Ja', 'noButton': 'Nej', 'feedbackQuestion': 'Är detta byggnadsklassen ni var ute efter?', 'feedbackReply':
+        'Tack för responsen!', 'excludesText': 'Innehåller ej: ', 'includesText': 'Innehåller: ', 'includesAlsoText': 'Innehåller också: ',
     'keywordsText': 'Nyckelord: '}};
 
 customElements.define('fs-detail', FsDetail);

--- a/src/fs-result.js
+++ b/src/fs-result.js
@@ -148,7 +148,7 @@ class FsResult extends HTMLElement {
     // Fetch classifications from stat.fi API
     async fetchData() {
         return await fetch(
-            'https://data.stat.fi/api/classifications/v1/classifications/rakennus_1_20180712/classificationItems?content=data&meta=max&lang=fi'
+            'https://data.stat.fi/api/classifications/v1/classifications/rakennus_1_20180712/classificationItems?content=data&meta=max&lang=' + this.language
         ).then((res) => res.json());
     }
 

--- a/test/fs-detail.test.js
+++ b/test/fs-detail.test.js
@@ -145,7 +145,7 @@ describe('Language tests', () => {
             expect(sr.querySelector('.feedback')).to.contain.html('Is this the building class you are looking for?');
             expect(sr.querySelector('.white')).to.contain.html('Excludes');
             expect(sr.querySelector('.white')).to.contain.html('Includes');
-            expect(sr.querySelector('.white')).to.contain.html('Includes also');
+            expect(sr.querySelector('.white')).to.contain.html('Also includes');
             expect(sr.querySelector('.white')).to.contain.html('Keywords');
 
             okButton.click();
@@ -165,8 +165,8 @@ describe('Language tests', () => {
 
             expect(okButton.textContent).to.eq('Ja');
             expect(sr.querySelector('.no').textContent).to.eq('Nej');
-            expect(sr.querySelector('.feedback')).to.contain.html('Är detta byggnadsklassen ni var efter?');
-            expect(sr.querySelector('.white')).to.contain.html('Innehåller inte');
+            expect(sr.querySelector('.feedback')).to.contain.html('Är detta byggnadsklassen ni var ute efter?');
+            expect(sr.querySelector('.white')).to.contain.html('Innehåller ej');
             expect(sr.querySelector('.white')).to.contain.html('Innehåller');
             expect(sr.querySelector('.white')).to.contain.html('Innehåller också');
             expect(sr.querySelector('.white')).to.contain.html('Nyckelord');

--- a/test/fs-result.test.js
+++ b/test/fs-result.test.js
@@ -10,7 +10,7 @@ import {sleep, mockResponse} from './util';
 let elem;
 let apiData;
 
-describe('List element test suite', () => {
+describe('Result element test suite', () => {
     before(async () => {
         sinon.stub(window, 'fetch').resolves(mockResponse(classifications));
 
@@ -105,10 +105,29 @@ describe('List element test suite', () => {
 
 describe('Language tests', () => {
     describe('.language', () => {
-        it('is bound to the `language` attribute', async () => {
-            const el = await fixture('<fs-question language="en"></fs-question>');
+        let el;
+        let fetchStub;
 
+        before(async () => {
+            fetchStub = sinon.stub(window, 'fetch').resolves(mockResponse(classifications));
+            el = await fixture('<fs-result language="en"></fs-result>');
+        });
+
+        after(() => {
+            window.fetch.restore();
+        });
+
+        it('is bound to the `language` attribute', async () => {
             expect(el.language).to.eq('en');
+        });
+
+        it('is used when fetching classifications', async () => {
+            const url = 'https://data.stat.fi/api/classifications/v1/classifications/rakennus_1_20180712/classificationItems?content=data&meta=max&lang=';
+
+            expect(fetchStub.calledWith(url + 'en')).to.equal(true);
+            el = await fixture('<fs-result language="sv"></fs-result>');
+
+            expect(fetchStub.calledWith(url + 'sv')).to.equal(true);
         });
     });
 


### PR DESCRIPTION
also moved setLanguage to connectedCallback so it's called before render even without defining language attribute